### PR TITLE
Update audacious-plugins to 4.2

### DIFF
--- a/srcpkgs/audacious-plugins/template
+++ b/srcpkgs/audacious-plugins/template
@@ -1,7 +1,7 @@
 # Template file for 'audacious-plugins'
 #Keep in sync with audacious!
 pkgname=audacious-plugins
-version=4.1
+version=4.2
 revision=4
 build_style=gnu-configure
 configure_args="$(vopt_enable gtk) $(vopt_enable qt)"
@@ -17,7 +17,7 @@ maintainer="Orphaned <orphan@voidlinux.org>"
 license="BSD-2-Clause"
 homepage="https://audacious-media-player.org/"
 distfiles="https://distfiles.audacious-media-player.org/${pkgname}-${version}.tar.bz2"
-checksum=dad6fc625055349d589e36e8e5c8ae7dfafcddfe96894806509696d82bb61d4c
+checksum=6fa0f69c3a1041eb877c37109513ab4a2a0a56a77d9e8c13a1581cf1439a417f
 
 build_options="gtk qt"
 build_options_default="qt"


### PR DESCRIPTION
I've changed the version number as well as the checksum. I've tested the package and audacious launches and is able to play music.

<!-- Uncomment relevant sections and delete options which are not applicable -->

#### Testing the changes
- I tested the changes in this PR: **YES**

<!--
#### New package
- This new package conforms to the [package requirements](https://github.com/void-linux/void-packages/blob/master/CONTRIBUTING.md#package-requirements): **YES**
-->

<!--
#### Local build testing
- I built this PR locally for my native architecture, (x86_64)
-->
